### PR TITLE
Fix middle section vertical alignment across bar regions

### DIFF
--- a/hancore.shibumi.bar/styles/shibumi/BarSurface.qml
+++ b/hancore.shibumi.bar/styles/shibumi/BarSurface.qml
@@ -335,6 +335,7 @@ Item {
         anchors.leftMargin: horizontalSurface.shellX
           + horizontalSurface.shellContentInset
         anchors.verticalCenter: runChrome.verticalCenter
+        height: runChrome.height
         z: 10
 
         Shibumi.GroupSection {
@@ -359,6 +360,7 @@ Item {
         id: centerRegion
 
         anchors.verticalCenter: runChrome.verticalCenter
+        height: runChrome.height
         x: horizontalSurface.centerTargetX
         z: 10
 
@@ -392,6 +394,7 @@ Item {
         anchors.rightMargin: horizontalSurface.shellX
           + horizontalSurface.shellContentInset
         anchors.verticalCenter: runChrome.verticalCenter
+        height: runChrome.height
         z: 10
 
         Core.BarSection {

--- a/hancore.shibumi.bar/styles/shibumi/GroupSection.qml
+++ b/hancore.shibumi.bar/styles/shibumi/GroupSection.qml
@@ -79,7 +79,7 @@ Item {
   implicitHeight: contentItem && "layoutHeight" in contentItem
     ? contentItem.layoutHeight : contentItem ? contentItem.implicitHeight : 0
   width: implicitWidth
-  height: implicitHeight
+  height: parent && parent.height > 0 ? parent.height : implicitHeight
 
   // QML Repeaters rebuild every delegate when a JavaScript array model is
   // replaced. V1 extension changes must retain existing widget owners (most
@@ -266,6 +266,8 @@ Item {
     Row {
       id: horizontalRow
 
+      height: parent && parent.height > 0 ? parent.height : implicitHeight
+      anchors.verticalCenter: parent ? parent.verticalCenter : undefined
       spacing: 0
       function scheduleLayout() {
         if (!layoutTimer.running) layoutTimer.start()
@@ -506,7 +508,8 @@ Item {
           implicitHeight: effectiveHasContent && root
             ? root.v2Mode ? targetVisual.height : 32 : 0
           width: implicitWidth
-          height: implicitHeight
+          height: parent && parent.height > 0 ? parent.height : implicitHeight
+          anchors.verticalCenter: parent ? parent.verticalCenter : undefined
           onWidthChanged: {
             if (horizontalRow) horizontalRow.scheduleLayout()
           }

--- a/styles/shibumi/BarSurface.qml
+++ b/styles/shibumi/BarSurface.qml
@@ -335,6 +335,7 @@ Item {
         anchors.leftMargin: horizontalSurface.shellX
           + horizontalSurface.shellContentInset
         anchors.verticalCenter: runChrome.verticalCenter
+        height: runChrome.height
         z: 10
 
         Shibumi.GroupSection {
@@ -359,6 +360,7 @@ Item {
         id: centerRegion
 
         anchors.verticalCenter: runChrome.verticalCenter
+        height: runChrome.height
         x: horizontalSurface.centerTargetX
         z: 10
 
@@ -392,6 +394,7 @@ Item {
         anchors.rightMargin: horizontalSurface.shellX
           + horizontalSurface.shellContentInset
         anchors.verticalCenter: runChrome.verticalCenter
+        height: runChrome.height
         z: 10
 
         Core.BarSection {

--- a/styles/shibumi/GroupSection.qml
+++ b/styles/shibumi/GroupSection.qml
@@ -79,7 +79,7 @@ Item {
   implicitHeight: contentItem && "layoutHeight" in contentItem
     ? contentItem.layoutHeight : contentItem ? contentItem.implicitHeight : 0
   width: implicitWidth
-  height: implicitHeight
+  height: parent && parent.height > 0 ? parent.height : implicitHeight
 
   // QML Repeaters rebuild every delegate when a JavaScript array model is
   // replaced. V1 extension changes must retain existing widget owners (most
@@ -266,6 +266,8 @@ Item {
     Row {
       id: horizontalRow
 
+      height: parent && parent.height > 0 ? parent.height : implicitHeight
+      anchors.verticalCenter: parent ? parent.verticalCenter : undefined
       spacing: 0
       function scheduleLayout() {
         if (!layoutTimer.running) layoutTimer.start()
@@ -506,7 +508,8 @@ Item {
           implicitHeight: effectiveHasContent && root
             ? root.v2Mode ? targetVisual.height : 32 : 0
           width: implicitWidth
-          height: implicitHeight
+          height: parent && parent.height > 0 ? parent.height : implicitHeight
+          anchors.verticalCenter: parent ? parent.verticalCenter : undefined
           onWidthChanged: {
             if (horizontalRow) horizontalRow.scheduleLayout()
           }


### PR DESCRIPTION
Align region container heights to runChrome.height in BarSurface.qml and propagate parent height alignment through GroupSection.qml.

This ensures left, center, and right regions maintain consistent vertical Y coordinates regardless of section-specific widget height variations.

Affected plugins: hancore.shibumi.bar
Checks executed:
- git diff --check
- ./scripts/sync-shared.sh --check
- ./scripts/sync-bar-host.sh --check
- python3 tests/test_package_release.py
- python3 tests/test_shibumi_health.py
- python3 tests/test_shibumi_manager.py
- python3 tests/test_shibumi_suite.py