### PR TITLE
fix(bar): resolve host widgets through enabled local clones

### DIFF
--- a/hancore.shibumi.bar/services/HostWidgetResolver.qml
+++ b/hancore.shibumi.bar/services/HostWidgetResolver.qml
@@ -18,9 +18,16 @@ QtObject {
     const registry = bar ? bar.pluginRegistry : null
     const plugins = registry && registry.installedPlugins
       ? registry.installedPlugins : null
-    const manifest = plugins ? plugins[String(widgetId || "")] : null
-    if (!manifest || !registry || typeof registry.entryPointUrl !== "function")
+    if (!registry || typeof registry.entryPointUrl !== "function")
       return ""
+    // Host widgets are addressed by their built-in id, but an enabled local
+    // clone replaces the implementation — the same rule the shell applies in
+    // PluginRegistry.resolveEnabledId.
+    let id = String(widgetId || "")
+    if (typeof registry.resolveEnabledId === "function")
+      id = registry.resolveEnabledId(id)
+    const manifest = plugins ? plugins[id] : null
+    if (!manifest) return ""
     return String(registry.entryPointUrl(manifest, "barWidget") || "")
   }
 


### PR DESCRIPTION
## Problem

`HostWidgetResolver.entryPointUrl()` looks up `installedPlugins[widgetId]` directly. Host integrations address widgets by their built-in id (`omarchy.network`), but after `omarchy plugin clone omarchy.network` the shell routes that id to the enabled clone (`semblante.network`) via `PluginRegistry.resolveEnabledId()` — the resolver never applies it, so the packaged original keeps loading.

On this machine that meant the Shibumi network presentation kept instantiating the packaged `omarchy.network` panel, which triggers repeated QML `Binding loop detected for property "height"` warnings in `/usr/share/omarchy/shell/plugins/panels/network/Panel.qml` (lines 1510/1795) on every panel open, surfacing as `SHIBUMI-HEALTH/RUNTIME-ERRORS` and `SHIBUMI-HEALTH/MANAGED-PLUGINS` failures.

## Change

`HostWidgetResolver.entryPointUrl()` now applies `registry.resolveEnabledId(widgetId)` (guarded by `typeof`) before resolving the manifest — the same rule the shell applies to its own IPC paths (`shell.qml` summon/hide/toggle/isPluginOpen). No other consumers change; without an enabled clone the id passes through unchanged.

## Verification

- Omarchy 4.0.0-1, quickshell-git 0.3.0.r20.g28771c7-1, Shibumi 0.1.1-beta.8
- `python3 tests/test_shibumi_suite.py` OK (31 tests), `python3 tests/test_shibumi_health.py` OK (31 tests), `git diff --check` clean
- `shibumi-suite repair --yes` re-staged the payload; health reports `managed-plugins: ok` and `runtime-errors: ok`
- Network presentation open/close via IPC after fix: 0 binding-loop warnings (previously 3 per open)