### PR TITLE
fix(bar): skip V1 reconciliation in V2 mode

### DIFF
--- a/Bar.qml
+++ b/Bar.qml
@@ -823,7 +823,8 @@ Item {
       ? pluginRegistry.isEnabled(id) : null
     const desiredSpecs = v1PluginSpecs(replacedProviderIds,
       installed === true ? { id: id, region: targetRegion } : null)
-    if (!layoutStateController.reconcileV1PluginGroups(desiredSpecs))
+    if (!layoutStateController.v2Mode
+        && !layoutStateController.reconcileV1PluginGroups(desiredSpecs))
       return false
 
     if (installed === true && pluginRegistry
@@ -860,7 +861,8 @@ Item {
         if (!Util.isPlainObject(config.bar)) config.bar = {}
         config.bar.layout = JSON.parse(JSON.stringify(previousLayout))
       })
-      layoutStateController.reconcileV1PluginGroups(previousSpecs)
+      if (!layoutStateController.v2Mode)
+        layoutStateController.reconcileV1PluginGroups(previousSpecs)
       if (registryWasEnabled === false && pluginRegistry
           && typeof pluginRegistry.setEnabled === "function")
         pluginRegistry.setEnabled(id, false)
@@ -880,7 +882,8 @@ Item {
       ? Object.keys(stateValues) : []
     const previousStates = groups.length > 0
       ? widgetGroupVariantStates(groups) : null
-    if (!layoutStateController.reconcileV1PluginGroups(desiredSpecs))
+    if (!layoutStateController.v2Mode
+        && !layoutStateController.reconcileV1PluginGroups(desiredSpecs))
       return false
     shell.mutateShellConfig(function(config) {
       if (!Util.isPlainObject(config.bar)) config.bar = {}
@@ -892,7 +895,8 @@ Item {
       if (!Util.isPlainObject(config.bar)) config.bar = {}
       config.bar.layout = JSON.parse(JSON.stringify(previousLayout))
     })
-    layoutStateController.reconcileV1PluginGroups(previousSpecs)
+    if (!layoutStateController.v2Mode)
+      layoutStateController.reconcileV1PluginGroups(previousSpecs)
     if (previousStates) setWidgetGroupVariantStates(previousStates)
     return false
   }

--- a/hancore.shibumi.bar/Bar.qml
+++ b/hancore.shibumi.bar/Bar.qml
@@ -823,7 +823,8 @@ Item {
       ? pluginRegistry.isEnabled(id) : null
     const desiredSpecs = v1PluginSpecs(replacedProviderIds,
       installed === true ? { id: id, region: targetRegion } : null)
-    if (!layoutStateController.reconcileV1PluginGroups(desiredSpecs))
+    if (!layoutStateController.v2Mode
+        && !layoutStateController.reconcileV1PluginGroups(desiredSpecs))
       return false
 
     if (installed === true && pluginRegistry
@@ -860,7 +861,8 @@ Item {
         if (!Util.isPlainObject(config.bar)) config.bar = {}
         config.bar.layout = JSON.parse(JSON.stringify(previousLayout))
       })
-      layoutStateController.reconcileV1PluginGroups(previousSpecs)
+      if (!layoutStateController.v2Mode)
+        layoutStateController.reconcileV1PluginGroups(previousSpecs)
       if (registryWasEnabled === false && pluginRegistry
           && typeof pluginRegistry.setEnabled === "function")
         pluginRegistry.setEnabled(id, false)
@@ -880,7 +882,8 @@ Item {
       ? Object.keys(stateValues) : []
     const previousStates = groups.length > 0
       ? widgetGroupVariantStates(groups) : null
-    if (!layoutStateController.reconcileV1PluginGroups(desiredSpecs))
+    if (!layoutStateController.v2Mode
+        && !layoutStateController.reconcileV1PluginGroups(desiredSpecs))
       return false
     shell.mutateShellConfig(function(config) {
       if (!Util.isPlainObject(config.bar)) config.bar = {}
@@ -892,7 +895,8 @@ Item {
       if (!Util.isPlainObject(config.bar)) config.bar = {}
       config.bar.layout = JSON.parse(JSON.stringify(previousLayout))
     })
-    layoutStateController.reconcileV1PluginGroups(previousSpecs)
+    if (!layoutStateController.v2Mode)
+      layoutStateController.reconcileV1PluginGroups(previousSpecs)
     if (previousStates) setWidgetGroupVariantStates(previousStates)
     return false
   }

--- a/hancore.shibumi.control-center/ControlCenterPanel.qml
+++ b/hancore.shibumi.control-center/ControlCenterPanel.qml
@@ -634,7 +634,9 @@ ShibumiPanel {
       const changed = setPluginBarWidgetEnabled(id, enabled === true, section)
       if (!changed)
         pluginActionError = enabled === true
-          ? "V1 has no free extension slot. Remove an active added plugin or free a V1 extension slot under Bars."
+          ? (v2LayoutActive
+            ? "The plugin could not be activated in the active bar layout."
+            : "V1 has no free extension slot. Remove an active added plugin or free a V1 extension slot under Bars.")
           : "The plugin could not be removed from the active bar."
       return changed
     }


### PR DESCRIPTION
## Summary

Skip `reconcileV1PluginGroups` when the shell is using the V2 layout.

V1 reconciliation rewrites `bar.layout` with V1-only group assignments, which removes any V2 layout state and leaves third-party plugins unable to enable or disable themselves from the control center.

This fix guards the three call sites in Bar.qml where `reconcileV1PluginGroups` is invoked:
- The install/uninstall flow (around line 826)
- The rollback path in the same flow (around line 864)
- `applyProviderLayoutTransaction` (around line 885 + rollback at 895)

In V2 mode, the reconciliation is skipped so the V2 layout is preserved.

## Additional fix

Updated the ControlCenterPanel error message to show a V2-specific hint when plugin activation fails in V2 mode, instead of always suggesting V1-only guidance.